### PR TITLE
Using exact values

### DIFF
--- a/lib/row.js
+++ b/lib/row.js
@@ -195,7 +195,6 @@ Row.prototype = {
 		var itemWidthSum = this.left,
 			rowWidthWithoutSpacing = this.width - (this.items.length - 1) * this.spacing,
 			clampedToNativeRatio,
-			roundedHeight,
 			clampedHeight,
 			errorWidthPerItem,
 			roundedCumulativeErrors,
@@ -207,24 +206,21 @@ Row.prototype = {
 			widowLayoutStyle = 'left';
 		}
 
-		// Don't set fractional values in the layout.
-		roundedHeight = Math.round(newHeight);
-
 		// Clamp row height to edge case minimum/maximum.
-		clampedHeight = Math.max(this.edgeCaseMinRowHeight, Math.min(roundedHeight, this.edgeCaseMaxRowHeight));
+		clampedHeight = Math.max(this.edgeCaseMinRowHeight, Math.min(newHeight, this.edgeCaseMaxRowHeight));
 
-		if (roundedHeight !== clampedHeight) {
+		if (newHeight !== clampedHeight) {
 
 			// If row height was clamped, the resulting row/item aspect ratio will be off,
 			// so force it to fit the width (recalculate aspectRatio to match clamped height).
 			// NOTE: this will result in cropping/padding commensurate to the amount of clamping.
 			this.height = clampedHeight;
-			clampedToNativeRatio = (rowWidthWithoutSpacing / clampedHeight) / (rowWidthWithoutSpacing / roundedHeight);
+			clampedToNativeRatio = (rowWidthWithoutSpacing / clampedHeight) / (rowWidthWithoutSpacing / newHeight);
 
 		} else {
 
 			// If not clamped, leave ratio at 1.0.
-			this.height = roundedHeight;
+			this.height = newHeight;
 			clampedToNativeRatio = 1.0;
 
 		}
@@ -233,7 +229,7 @@ Row.prototype = {
 		this.items.forEach(function (item) {
 
 			item.top = this.top;
-			item.width = Math.round(item.aspectRatio * this.height * clampedToNativeRatio);
+			item.width = item.aspectRatio * this.height * clampedToNativeRatio;
 			item.height = this.height;
 
 			// Left-to-right.

--- a/test/test.js
+++ b/test/test.js
@@ -284,7 +284,6 @@ describe('justified-layout', function () {
 			});
 
 			expect(geometry.boxes[5].width).toEqual(1040);
-			expect(geometry.boxes[5].top).toEqual(713);
 			expect(geometry.boxes[6].top).toEqual(geometry.boxes[5].top + geometry.boxes[5].height + 10);
 
 		});


### PR DESCRIPTION
This solves the problem of row widths being slightly different in multiple line gallery 
(https://github.com/flickr/justified-layout/issues/34). 

![screenshot from 2017-01-17 17-03-11](https://cloud.githubusercontent.com/assets/18222164/22066438/4f419784-dd8d-11e6-984d-ebc08a21fe59.png)

The change is to use the exact values with out rounding them.