### PR TITLE
Do not apply widowLayoutStyle to full width row

### DIFF
--- a/lib/row.js
+++ b/lib/row.js
@@ -106,7 +106,7 @@ Row.prototype = {
 				if (itemData.aspectRatio >= 1) {
 					// Close out the row with a full width photo
 					this.items.push(itemData);
-					this.completeLayout(rowWidthWithoutSpacing / itemData.aspectRatio, this.widowLayoutStyle);
+					this.completeLayout(rowWidthWithoutSpacing / itemData.aspectRatio, 'justify');
 					return true;
 				}
 			}
@@ -131,7 +131,7 @@ Row.prototype = {
 				// When there are no existing items, force acceptance of the new item and complete the layout.
 				// This is the pano special case.
 				this.items.push(merge(itemData));
-				this.completeLayout(rowWidthWithoutSpacing / newAspectRatio, this.widowLayoutStyle);
+				this.completeLayout(rowWidthWithoutSpacing / newAspectRatio, 'justify');
 				return true;
 
 			}
@@ -146,7 +146,7 @@ Row.prototype = {
 			if (Math.abs(newAspectRatio - targetAspectRatio) > Math.abs(previousAspectRatio - previousTargetAspectRatio)) {
 
 				// Row with new item is us farther away from target than row without; complete layout and reject item.
-				this.completeLayout(previousRowWidthWithoutSpacing / previousAspectRatio, this.widowLayoutStyle);
+				this.completeLayout(previousRowWidthWithoutSpacing / previousAspectRatio, 'justify');
 				return false;
 
 			} else {
@@ -154,7 +154,7 @@ Row.prototype = {
 				// Row with new item is us closer to target than row without;
 				// accept the new item and complete the row layout.
 				this.items.push(merge(itemData));
-				this.completeLayout(rowWidthWithoutSpacing / newAspectRatio, this.widowLayoutStyle);
+				this.completeLayout(rowWidthWithoutSpacing / newAspectRatio, 'justify');
 				return true;
 
 			}
@@ -164,7 +164,7 @@ Row.prototype = {
 			// New aspect ratio / scaled row height is within tolerance;
 			// accept the new item and complete the row layout.
 			this.items.push(merge(itemData));
-			this.completeLayout(rowWidthWithoutSpacing / newAspectRatio, this.widowLayoutStyle);
+			this.completeLayout(rowWidthWithoutSpacing / newAspectRatio, 'justify');
 			return true;
 
 		}
@@ -188,7 +188,7 @@ Row.prototype = {
 	*
 	* @method completeLayout
 	* @param newHeight {Number} Set row height to this value.
-	* @param widowLayoutStyle {String} How should widows display? Supported: justify | center
+	* @param widowLayoutStyle {String} How should widows display? Supported: left | justify | center
 	*/
 	completeLayout: function (newHeight, widowLayoutStyle) {
 


### PR DESCRIPTION
#33 introduces new prop 'widowLayoutStyle'.
'widowLayoutStyle' should be applied to widow only.
This PR restores full-width row to justified layout.

It should fix #34 and #36.