### PR TITLE
Configurable edgeCaseTargetRowHeights

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,8 +36,8 @@ function createNewRow(layoutConfig, layoutData) {
 		spacing: layoutConfig.boxSpacing.horizontal,
 		targetRowHeight: layoutConfig.targetRowHeight,
 		targetRowHeightTolerance: layoutConfig.targetRowHeightTolerance,
-		edgeCaseMinRowHeight: 0.5 * layoutConfig.targetRowHeight,
-		edgeCaseMaxRowHeight: 2 * layoutConfig.targetRowHeight,
+		edgeCaseMinRowHeight: layoutConfig.edgeCaseMinRowHeight,
+		edgeCaseMaxRowHeight: layoutConfig.edgeCaseMaxRowHeight,
 		rightToLeft: false,
 		isBreakoutRow: isBreakoutRow,
 		widowLayoutStyle: layoutConfig.widowLayoutStyle
@@ -215,6 +215,8 @@ module.exports = function (input, config) {
 
 	// Merge defaults and config passed in
 	layoutConfig = merge(defaults, config);
+	layoutConfig.edgeCaseMinRowHeight = layoutConfig.edgeCaseMinRowHeight !== undefined ? layoutConfig.edgeCaseMinRowHeight : 0.5 * layoutConfig.targetRowHeight;
+	layoutConfig.edgeCaseMaxRowHeight = layoutConfig.edgeCaseMaxRowHeight !== undefined ? layoutConfig.edgeCaseMaxRowHeight : 2 * layoutConfig.targetRowHeight;
 
 	// Sort out padding and spacing values
 	containerPadding.top = (!isNaN(parseFloat(layoutConfig.containerPadding.top))) ? layoutConfig.containerPadding.top : layoutConfig.containerPadding;


### PR DESCRIPTION
In my setup, I want to display panoramic photos and unfortunately they are squished if they are too wide. This PR adds the option to override the minimum and maximum row height.

The default behaviour is preserved unless it is changed with a config option.